### PR TITLE
Dockerfile: Run composer install in ENTRYPOINT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=https://localhost
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN cp $PHP_INI_DIR/php.ini-development $PHP_INI_DIR/php.ini; \
     sed -i 's/variables_order = "GPCS"/variables_order = "EGPCS"/' $PHP_INI_DIR/php.ini;
 
-ENTRYPOINT ["php", "artisan", "octane:start", "--server=frankenphp", "--host=localhost", "--port=443", "--admin-port=2019", "--https"]
+ENTRYPOINT ["/bin/sh", "-c" , "composer install && php artisan octane:start --server=frankenphp --host=localhost --port=443 --admin-port=2019 --https"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a modern, strict, strongly typed Laravel application skeleton that can b
 
 You should ensure that you have the following installed on your host machine:
 
+* Git
 * Docker
 * Docker-compose
 * pnpm v8
@@ -40,28 +41,34 @@ Front end:
 
 ## Getting started
 
-1. Install front end dependencies:
+1. Clone this repo:
+   ```shell
+   git clone git@github.com:philbates35/laravel-starter.git example-project
+   cd example-project
+   ```
+
+2. Create the `.env` file:
+   ```shell
+   cp .env.example .env
+   ```
+
+3. Install composer dependencies, then start Octane (FrankenPHP):
+    ```shell
+    docker-compose up -d
+    ```
+
+4. Install front end dependencies:
     ```shell
     pnpm install
     ```
 
-2. Run the Vite dev server:
+5. Run the Vite dev server:
 
     ```shell
     pnpm run dev
     ```
 
-3. Install composer dependencies:
-    ```shell
-    docker run --rm -it -u $(id -u $USER) -v $PWD:/app composer:latest composer install
-    ```
-
-4. Start Octane (FrankenPHP):
-    ```shell
-    docker-compose up -d
-    ```
-
-5. Go to https://localhost/, accept the potential security risk (it's a self-signed certificate), and you should see the Laravel welcome page.
+6. Go to https://localhost/, accept the potential security risk (it's a self-signed certificate), and you should see the Laravel welcome page.
 
 ## Cheat sheet
 

--- a/config/app.php
+++ b/config/app.php
@@ -57,7 +57,7 @@ return [
     |
     */
 
-    'url' => env('APP_URL', 'http://localhost'),
+    'url' => env('APP_URL', 'https://localhost'),
 
     'asset_url' => env('ASSET_URL'),
 


### PR DESCRIPTION
I realised going through the docs the getting started steps on a fresh project didn't work, there were a couple of issues:

1. The `.env` wasn't being created
2. The `composer:latest` used to do the initial `composer install` uses PHP8.2 but the project requires PHP8.3 so it fails. It makes much more sense to do the `composer install` as part of the initial `docker-compose up` meaning one less step for the developer.