### PR TITLE
ESLint: Remove incorrect ignorePatterns

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,5 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "prettier",
   ],
-  ignorePatterns: ["dist", ".eslintrc.cjs"],
   parser: "@typescript-eslint/parser",
 };


### PR DESCRIPTION
1. We don't have a `dist/` dir (this was copied over from the Vite react-ts starter that does have a `dist/` dir by mistake)
2. Why not include `.eslintrc.cjs`
3. We already have an `.eslintignore`, that should be the source of truth for all things related to file ignoring, there's no point spreading the logic across two files.