### PR TITLE
TS: Allow absolute imports via @/*

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,11 @@
     "isolatedModules": true,
     "noEmit": true,
 
+    /* Absolute imports */
+    "paths": {
+      "@/*": ["./resources/js/*"],
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
The `laravel-vite-plugin` already comes with the Vite `@/*` alias set up to point to `resources/js/`, but it isn't currently possible to use it because `tsc` fails.