### PR TITLE
PHPStan: Ignore "Dynamic call to static method" errors

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,3 +16,7 @@ parameters:
     level: 9
     excludePaths:
         - bootstrap/cache/
+    strictRules:
+        # TODO remove when https://github.com/phpstan/phpstan-strict-rules/issues/140 is resolved
+        # See also: https://github.com/larastan/larastan/issues/1272
+        strictCalls: false


### PR DESCRIPTION
The following route:

```php
    Route::get('/', function(\Illuminate\Contracts\Filesystem\Filesystem $factory) {
        return $factory->download('foo.csv');
    });
```
currently results in the following false-positive error:

```
     ------ ------------------------------------------------------------------------------------
      Line   routes/web.php
     ------ ------------------------------------------------------------------------------------
      22     Dynamic call to static method Illuminate\Filesystem\FilesystemAdapter::download().
     ------ ------------------------------------------------------------------------------------
```

See https://github.com/phpstan/phpstan-strict-rules/issues/140
See https://github.com/larastan/larastan/issues/1272