### PR TITLE
ESLint: Use strict & stylistic @typescript-eslint rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,12 +3,17 @@ module.exports = {
   env: { browser: true, es2020: true },
   extends: [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/strict-type-checked",
+    "plugin:@typescript-eslint/stylistic-type-checked",
     "plugin:import/recommended",
     "plugin:import/typescript",
     "prettier",
   ],
   parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: ["./tsconfig.json", "./tsconfig.node.json"],
+    tsconfigRootDir: __dirname,
+  },
   plugins: ["import"],
   rules: {
     "import/exports-last": "error",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
The reason for adding `strict: true` to `tsconfig.node.json` is because without it, eslint now fails with the following errors:

    [philbates@fedora laravel-starter]$ pnpm run lint

    > @ lint /home/philbates/code/philbates35/laravel-starter
    > eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0

    /home/philbates/code/philbates35/laravel-starter/vite.config.ts
      0:1  error  This rule requires the `strictNullChecks` compiler option to be turned on to function correctly  @typescript-eslint/prefer-nullish-coalescing
      0:1  error  This rule requires the `strictNullChecks` compiler option to be turned on to function correctly  @typescript-eslint/no-unnecessary-condition

See:
* https://typescript-eslint.io/linting/typed-linting/
* https://typescript-eslint.io/linting/configs/