### PR TITLE
PHPStan: Use bleeding edge

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,7 +30,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     protected $hidden = [
         'password',

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -30,7 +30,7 @@ class RouteServiceProvider extends ServiceProvider
     {
         RateLimiter::for(
             'api',
-            static fn(Request $request) => Limit::perMinute(60)->by($request->user()?->id ?? $request->ip()),
+            static fn(Request $request) => Limit::perMinute(60)->by($request->user()->id ?? $request->ip()),
         );
 
         $this->routes(static function (): void {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 */
 
 $app = new Illuminate\Foundation\Application(
-    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__),
+    isset($_ENV['APP_BASE_PATH']) && is_string($_ENV['APP_BASE_PATH']) ? $_ENV['APP_BASE_PATH'] : dirname(__DIR__),
 );
 
 /*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,5 @@
 includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - vendor/larastan/larastan/extension.neon
     - vendor/phpstan/phpstan-mockery/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon


### PR DESCRIPTION
See:
* https://phpstan.org/blog/what-is-bleeding-edge
* https://backendtea.com/post/use-phpstan-bleeding-edge/

Fix the following three new highlighted issues at the same time:

```
[philbates@fedora laravel-starter]$ docker-compose exec php composer run phpstan -- --memory-limit=512M
> phpstan --ansi '--memory-limit=512M'
Note: Using configuration file /app/phpstan.neon.dist.
 50/50 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   app/Models/User.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  35     PHPDoc type array<int, string> of property App\Models\User::$hidden is not the same as PHPDoc type list<string> of overridden property Illuminate\Database\Eloquent\Model::$hidden.
         💡 You can fix 3rd party PHPDoc types with stub files:
         💡 https://phpstan.org/user-guide/stub-files

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------
  Line   app/Providers/RouteServiceProvider.php
 ------ -------------------------------------------------------------------------------------------
  33     Using nullsafe property access "?->id" on left side of ?? is unnecessary. Use -> instead.
 ------ -------------------------------------------------------------------------------------------

 ------ -----------------------------------------------------------------------------------------------------------------
  Line   bootstrap/app.php
 ------ -----------------------------------------------------------------------------------------------------------------
  17     Parameter #1 $basePath of class Illuminate\Foundation\Application constructor expects string|null, mixed given.
 ------ -----------------------------------------------------------------------------------------------------------------
```