### PR TITLE
tsc: Pass -b flag so that vite.config.ts is type checked

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b && vite build",
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     exclude: [...configDefaults.exclude, ...projectExcludes],
     coverage: {
       provider: "v8",
-      exclude: [...configDefaults.coverage.exclude, ...projectExcludes],
+      exclude: [...(configDefaults.coverage.exclude ?? []), ...projectExcludes],
     },
     setupFiles: ["resources/js/setupFile.ts"],
   },


### PR DESCRIPTION
It highlighted the following error:

    [philbates@fedora laravel-starter]$ pnpm run build

    > @ build /home/philbates/code/philbates35/laravel-starter
    > tsc -b && vite build

    vite.config.ts:33:20 - error TS2461: Type 'string[] | undefined' is not an array type.

    33       exclude: [...configDefaults.coverage.exclude, ...projectExcludes],
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    Found 1 error.

See https://github.com/vitejs/vite/pull/15913.