### PR TITLE
.gitignore: Ignore *.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Homestead.yaml
 auth.json
 npm-debug.log
 yarn-error.log
+*.tsbuildinfo
 /.fleet
 /.idea
 /.vscode


### PR DESCRIPTION
This file now starts to be created now that we're passing "-b" to tsc.