### PR TITLE
Translation: Don't use Lang::handleMissingKeysUsing

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,10 +7,7 @@ namespace App\Providers;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Translation\Translator;
-use OutOfBoundsException;
 use Override;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,19 +18,7 @@ class AppServiceProvider extends ServiceProvider
     #[Override]
     public function register(): void
     {
-        $this->app->resolving('translator', function (Translator $translator): void {
-            $translator->handleMissingKeysUsing(function (string $key): string {
-                $message = "Missing translation key [{$key}] detected.";
-
-                if (!$this->isProduction()) {
-                    throw new OutOfBoundsException($message);
-                }
-
-                Log::warning($message);
-
-                return $key;
-            });
-        });
+        //
     }
 
     /**


### PR DESCRIPTION
Turns out this feature isn't particularly useful because it fires every time validation occurs. The feature has since been removed from the Laravel docs.

See https://github.com/laravel/framework/pull/49948