### PR TITLE
tsconfig: Use ESNext in target and lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ESNext",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
From what I can tell, the value of target doesn't actually matter, because we have `noEmit` set to true - its esbuild in dev (configured by Vite's `esbuild.target`) and Rollup for prod build (configured by `build.target`) that do the transpiling, but there's no harm in updating it anyway.

Setting `lib` to include `ESNext` allows us to use more modern features such as "promise.any, string.replaceAll etc" (ES2021) and "array.at, RegExp.hasIndices, etc." (ES2022).

Its also worth noting that these are the values of the `tsconfig.json` that come when using Laravel Breeze with one of its TS starters.

See:
* https://www.typescriptlang.org/tsconfig#lib
* https://www.typescriptlang.org/tsconfig#target
* https://github.com/laravel/breeze/blob/095c4c597c3719e2a596fcf4689288e9cdbc6520/stubs/inertia-react-ts/tsconfig.json