### PR TITLE
Upgrade to phpcs 3.9 and re-enable AddTypeToConstRector rule

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8534,16 +8534,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
                 "shasum": ""
             },
             "require": {
@@ -8610,7 +8610,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-01-11T20:47:48+00:00"
+            "time": "2024-02-16T15:06:51+00:00"
         },
         {
             "name": "symfony/filesystem",

--- a/rector.php
+++ b/rector.php
@@ -21,7 +21,9 @@ return RectorConfig::configure()
     // Larastan's bootstrap file doesn't run when Rector boots PHPStan, so we need to include it manually. See:
     //   * https://github.com/rectorphp/rector/issues/8006
     //   * https://github.com/larastan/larastan/issues/1664#issuecomment-1637152828
-    ->withBootstrapFiles([__DIR__ . '/vendor/larastan/larastan/bootstrap.php'])
+    ->withBootstrapFiles([
+        __DIR__ . '/vendor/larastan/larastan/bootstrap.php',
+    ])
     ->withPHPStanConfigs([
         __DIR__ . '/phpstan.neon.dist',
     ])

--- a/rector.php
+++ b/rector.php
@@ -22,8 +22,6 @@ return RectorConfig::configure()
     //   * https://github.com/rectorphp/rector/issues/8006
     //   * https://github.com/larastan/larastan/issues/1664#issuecomment-1637152828
     ->withBootstrapFiles([__DIR__ . '/vendor/larastan/larastan/bootstrap.php'])
-    // All extensions except PHPStan bleeding edge. See:
-    //   * https://github.com/rectorphp/rector/issues/8492#issuecomment-1944428821
     ->withPHPStanConfigs([
         __DIR__ . '/phpstan.neon.dist',
     ])

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php83\Rector\ClassConst\AddTypeToConstRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use RectorLaravel\Set\LaravelSetList;
 
@@ -49,8 +48,4 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         __DIR__ . '/bootstrap/cache',
-
-        // TODO Stop skipping this rule as soon as phpcs supports typed const
-        //     See: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/106
-        AddTypeToConstRector::class,
     ]);


### PR DESCRIPTION
Now that phpcs supports typed consts since we upgraded to v3.9
we can use this rule again.