### PR TITLE
php-cs-fixer: Disable single_line_empty_body

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -41,6 +41,7 @@ return (new PhpCsFixer\Config())
         'no_trailing_comma_in_singleline' => true,
         // 'numeric_literal_separator' => true,
         'psr_autoloading' => true,
+        'single_line_empty_body' => false,
 
         // Casing
         'class_reference_name_casing' => true,


### PR DESCRIPTION
This rule conflicts with phpcs which does the opposite of this rule meaning its impossible to ever get them both to pass.